### PR TITLE
isp-imx/-phycam.bbappend: add fsl-eula flag to SRC_URI

### DIFF
--- a/recipes-bsp/isp-imx/isp-imx-phycam_4.2.2.16.0.bbappend
+++ b/recipes-bsp/isp-imx/isp-imx-phycam_4.2.2.16.0.bbappend
@@ -1,2 +1,2 @@
 SRC_URI_remove = "${FSL_MIRROR}/isp-imx-${PV}.bin;fsl-eula=true"
-SRC_URI_append = "https://download.phytec.de/Software/Linux/Yocto/SourceMirror/isp-imx-${PV}_lost_version_1.bin;downloadfilename=isp-imx-${PV}.bin"
+SRC_URI_append = "https://download.phytec.de/Software/Linux/Yocto/SourceMirror/isp-imx-${PV}_lost_version_1.bin;downloadfilename=isp-imx-${PV}.bin;fsl-eula=true"

--- a/recipes-bsp/isp-imx/isp-imx_4.2.2.16.0.bbappend
+++ b/recipes-bsp/isp-imx/isp-imx_4.2.2.16.0.bbappend
@@ -1,2 +1,2 @@
 SRC_URI_remove = "${FSL_MIRROR}/isp-imx-${PV}.bin;fsl-eula=true"
-SRC_URI_append = "https://download.phytec.de/Software/Linux/Yocto/SourceMirror/isp-imx-${PV}_lost_version_1.bin;downloadfilename=isp-imx-${PV}.bin"
+SRC_URI_append = "https://download.phytec.de/Software/Linux/Yocto/SourceMirror/isp-imx-${PV}_lost_version_1.bin;downloadfilename=isp-imx-${PV}.bin;fsl-eula=true"


### PR DESCRIPTION
Without fsl-eula=true set in SRC_URI, the downloaded bin-file can not be unpacked and an error will occure while trying to apply patches.

Signed-off-by: Norbert Wesp <n.wesp@phytec.de>